### PR TITLE
Reset font-weight to "normal" on headers

### DIFF
--- a/src/playbook-stylesheet.js
+++ b/src/playbook-stylesheet.js
@@ -37,7 +37,8 @@ export default {
   },
   "h1, h2, h3, h4, h5, h6, hgroup": {
     fontFamily: theme.sansSerif,
-    letterSpacing: ".02em"
+    letterSpacing: ".02em",
+    fontWeight: "normal"
   },
   a: {
     color: theme.red,


### PR DESCRIPTION
They were being treated with faux-boldness.

/cc @exogen @ebrillhart @tptee @bmathews 