### PR TITLE
Feature scrape links on build

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,2 @@
+---
+extends: ./node_modules/builder-docs-archetype/config/eslint/.eslintrc-config

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ build/Release
 
 # Built site files
 build
+links.json
 
 # Dependency directories
 node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ install:
 
 script:
   - npm test
-  - NODE_ENV=production node_modules/.bin/builder run build-static
   - npm run scrape-links
+  - NODE_ENV=production node_modules/.bin/builder run build-static
 
 # Once build on Travis is working, automatically deploy it on master only:
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ install:
 script:
   - npm test
   - NODE_ENV=production node_modules/.bin/builder run build-static
+  - npm run scrape-links
 
 # Once build on Travis is working, automatically deploy it on master only:
 deploy:

--- a/package.json
+++ b/package.json
@@ -4,14 +4,15 @@
   "description": "The Formidable Playbook",
   "main": "",
   "scripts": {
-    "start": "builder run dev",
+    "start": "builder run scrape-links && builder run dev",
     "dev": "webpack-dev-server --port 3000 --config node_modules/builder-docs-archetype/config/webpack/webpack.config.dev.js --history-api-fallback",
     "test": "builder run lint",
     "copy-assets": "cp -r static build/static && cp -r ./node_modules/formidable-playbook/examples build",
     "server-examples": "http-server examples -p 3000 .",
     "lint": "builder concurrent lint-react lint-config lint-test lint-examples",
     "lint-examples": "eslint --ext .js,.jsx examples --ignore-pattern **/dist/",
-    "update-project": "npm update formidable-playbook"
+    "update-project": "npm update formidable-playbook",
+    "scrape-links": "node scrape-links.js"
   },
   "repository": {
     "type": "git",

--- a/scrape-links.js
+++ b/scrape-links.js
@@ -1,0 +1,26 @@
+"use strict";
+var path = require("path");
+var fs = require("fs");
+var PATH = "./node_modules/formidable-playbook";
+var OUTPUT = "./links.json";
+var README = path.join(PATH, "README.md");
+var REGEX = /\[(.*)\]\((?!http)(?!#)(.*)\)/gm;
+
+fs.readFile(README, "utf8", function (error, data) {
+  if (error) {
+    throw error;
+  }
+
+  var links = [];
+  var result = REGEX.exec(data);
+  while(result) {
+    links.push({
+      label: result[1],
+      route: "/" + result[2].split(".md")[0],
+    });
+
+    result = REGEX.exec(data);
+  }
+
+  fs.writeFile(OUTPUT, JSON.stringify(links));
+});

--- a/scrape-links.js
+++ b/scrape-links.js
@@ -1,26 +1,38 @@
 "use strict";
+
 var path = require("path");
 var fs = require("fs");
-var PATH = "./node_modules/formidable-playbook";
-var OUTPUT = "./links.json";
+var md = require("markdown-it")();
+
+var PATH = path.dirname(require.resolve("formidable-playbook/package.json"));
 var README = path.join(PATH, "README.md");
-var REGEX = /\[(.*)\]\((?!http)(?!#)(.*)\)/gm;
+var LINKS = "./links.json";
 
-fs.readFile(README, "utf8", function (error, data) {
-  if (error) {
-    throw error;
-  }
+fs.readFile(README, "utf8", function (readErr, data) {
+  if (readErr) { throw readErr; }
 
-  var links = [];
-  var result = REGEX.exec(data);
-  while(result) {
-    links.push({
-      label: result[1],
-      route: "/" + result[2].split(".md")[0],
+  var links = md.parse(data)
+    // Convert to useful info for us for top-level links.
+    .map(function (token) {
+      // Look for children of size three (link open, text, link close).
+      var children = token.children || [];
+      if (children.length !== 3) { return {}; } // eslint-disable-line no-magic-numbers
+
+      // Grab the route from href attr.
+      var route = ((children[0].attrs || [])[0] || [])[1] || "";
+
+      // Convert to final form for links.
+      return {
+        label: (children[1] || []).content,
+        route: "/" + route.split(".md")[0]
+      };
+    })
+    // Limit to top-level links that start with `docs/`
+    .filter(function (obj) {
+      return (obj.route || "").indexOf("/docs/") === 0;
     });
 
-    result = REGEX.exec(data);
-  }
-
-  fs.writeFile(OUTPUT, JSON.stringify(links));
+  fs.writeFile(LINKS, JSON.stringify(links, null, 2), function (writeErr) {
+    if (writeErr) { throw writeErr; }
+  });
 });

--- a/src/config.js
+++ b/src/config.js
@@ -1,33 +1,9 @@
-// The order should mirror the README TOC
-module.exports = [
-  {
-    label: "Having a Single Infrastructure",
-    route: "/docs/infrastructure/single",
-    file: require("!!raw!../node_modules/formidable-playbook/docs/infrastructure/single.md")
-  },
-  {
-    label: "Webpack Plugins",
-    route: "/docs/frontend/webpack-plugins",
-    file: require("!!raw!../node_modules/formidable-playbook/docs/frontend/webpack-plugins.md")
-  },
-  {
-    label: "Webpack Code Splitting",
-    route: "/docs/frontend/webpack-code-splitting",
-    file: require("!!raw!../node_modules/formidable-playbook/docs/frontend/webpack-code-splitting.md")
-  },
-  {
-    label: "Webpack Shared Libraries",
-    route: "/docs/frontend/webpack-shared-libs",
-    file: require("!!raw!../node_modules/formidable-playbook/docs/frontend/webpack-shared-libs.md")
-  },
-  {
-    label: "Webpack Tree Shaking",
-    route: "/docs/frontend/webpack-tree-shaking",
-    file: require("!!raw!../node_modules/formidable-playbook/docs/frontend/webpack-tree-shaking.md")
-  },
-  {
-    label: "Webpack Source Maps",
-    route: "/docs/frontend/webpack-source-maps",
-    file: require("!!raw!../node_modules/formidable-playbook/docs/frontend/webpack-source-maps.md")
-  }
-];
+import links from "../links";
+
+export default links.map(({label, route}) => {
+  return {
+    label,
+    route,
+    file: require(`!!raw!../node_modules/formidable-playbook${route}.md`)
+  };
+});

--- a/src/config.js
+++ b/src/config.js
@@ -1,9 +1,10 @@
 import links from "../links";
 
-export default links.map(({label, route}) => {
-  return {
-    label,
-    route,
-    file: require(`!!raw!../node_modules/formidable-playbook${route}.md`)
-  };
-});
+// Dynamically import all `docs/**/*.md` files.
+const mdRequire = require.context("!!raw!formidable-playbook", true, /docs\/.*\.md$/);
+
+export default links.map(({label, route}) => ({
+  label,
+  route,
+  file: mdRequire(`.${route}.md`)
+}));

--- a/static-routes.js
+++ b/static-routes.js
@@ -1,11 +1,7 @@
 "use strict";
-// The order should mirror the README TOC
-module.exports = [
-  "/",
-  "/docs/infrastructure/single",
-  "/docs/frontend/webpack-plugins",
-  "/docs/frontend/webpack-code-splitting",
-  "/docs/frontend/webpack-shared-libs",
-  "/docs/frontend/webpack-tree-shaking",
-  "/docs/frontend/webpack-source-maps"
-];
+
+var links = require("./links");
+
+module.exports = ["/"].concat(links.map(function (link) {
+  return link.route;
+}));


### PR DESCRIPTION
> ryan.roemer
For the link re-order, a great future ticket might be to have a build step actually _parse_ the `README.md`, extract the relative links, and keep them in order to build the route list.

This scrapes the `formidable-playbook/README.md` relative links and maintains their order.  The scraped links are output to a file which is used to generate the `static-links.js` and `config.js` files.  Links no longer have to be manually edited when updates are made to `formidable-playbook/README.md`.

I'm not sure if my edited`.travis.yml` will run properly, so double checking that would be awesome!

/cc @ryan-roemer @paulathevalley @ebrillhart 