### PR TITLE
setMarkDownRender in componentWillRecieveProps if currentPath changes

### DIFF
--- a/src/components/documentation.js
+++ b/src/components/documentation.js
@@ -8,6 +8,12 @@ class Documentation extends React.Component {
     this.setMarkdownRender(this.props.currentPath);
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.currentPath !== this.props.currentPath) {
+      this.setMarkdownRender(nextProps.currentPath);
+    }
+  }
+
   setMarkdownRender(currentPath) {
     const md = new MarkdownIt({
       html: true,


### PR DESCRIPTION
Fixes issue of table of content paths pointing to previous section when clicking into next or previous (ie `Tree Shaking` --> `Source Maps`). The component is not re-mounting so we are checking `componentWillRecieveProps` and updating the path if `currentPath` is different. 

@ryan-roemer - Does this look like an appropriate solution to you?